### PR TITLE
stderrを./errに出力するようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /qual_A
 /tools/out
+/tools/err

--- a/tools/src/bin/tester.rs
+++ b/tools/src/bin/tester.rs
@@ -28,7 +28,7 @@ fn main() {
     pb.set_style(sty);
     let pb = Arc::new(Mutex::new(pb));
 
-    let pool = ThreadPool::new(1);
+    let pool = ThreadPool::new(12);
     let total_score = Arc::new(Mutex::new(0));
     let mut case_num = 0_i64;
     for file in files {

--- a/tools/src/bin/tester.rs
+++ b/tools/src/bin/tester.rs
@@ -11,6 +11,8 @@ use threadpool::ThreadPool;
 fn main() {
     fs::remove_dir_all("./tools/out").unwrap();
     fs::create_dir("./tools/out").unwrap();
+    fs::remove_dir_all("./tools/err").unwrap();
+    fs::create_dir("./tools/err").unwrap();
     let files = fs::read_dir("./tools/in/")
         .unwrap()
         .into_iter()
@@ -26,7 +28,7 @@ fn main() {
     pb.set_style(sty);
     let pb = Arc::new(Mutex::new(pb));
 
-    let pool = ThreadPool::new(12);
+    let pool = ThreadPool::new(1);
     let total_score = Arc::new(Mutex::new(0));
     let mut case_num = 0_i64;
     for file in files {
@@ -52,6 +54,7 @@ fn exec(file_path: PathBuf) -> i64 {
     let file_name = file_path.file_name().unwrap().to_string_lossy();
     let in_file = format!("./tools/in/{file_name}");
     let out_file = format!("./tools/out/{file_name}");
+    let err_file = format!("./tools/err/{file_name}");
     {
         // 実行部分
         let p = std::process::Command::new("cargo")
@@ -77,6 +80,8 @@ fn exec(file_path: PathBuf) -> i64 {
         let output = p.wait_with_output().unwrap();
         let mut file = fs::File::create(out_file).unwrap();
         file.write_all(&output.stdout).unwrap();
+        let mut file = fs::File::create(err_file).unwrap();
+        file.write_all(&output.stderr).unwrap();
     };
 
     // ジャッジ部分


### PR DESCRIPTION
普段標準エラー出力に実行時間や得点を出力することが多いため、標準エラー出力をerrディレクトリに出力するようにした方が便利なのですが、いかがでしょうか。